### PR TITLE
Remove numpy import  from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages
-from numpy.distutils.core import setup
+#from numpy.distutils.core import setup
 from os import path
 import io
 


### PR DESCRIPTION
The numpy import makes the installation not portable to systems that do not already have numpy installed, and there is no automated way this can be handled. The setup.py script should ideally be completely portable. I tested this change and installed using `pip install .` and it seems to work fine. 